### PR TITLE
add preview with select and select snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,14 @@ Every snippets starts with either `sanity(...)` or `groq(...)`, so you know they
 - **Sanity Array Validation (min & max)** (`sanityArrValidation`): Validate an array field based on its length
 - **Sanity Basic Array** (`sanityArrFld`): Create a basic array field in Sanity
 - **Sanity Reference Field** (`sanityRefFld`): Create a basic reference field in Sanity
+- **Sanity Preview with Select** (`sanityPreviewSelect`): Add a basic preview with selection object in Sanity
+- **Sanity Preview with Select and Prepare** (`sanityPreviewSelectPrepare`): Add a preview with selection object and prepare function in Sanity
+- **Sanity Select Object** (`sanitySelect`): Add a basic selection object for preview in Sanity
+- **Sanity Prepare Function** (`sanityPrepare`): Add a prepare function for preview in Sanity
 - **GROQ block drafts constraint** (`groqDraftConstraint`): Constraint for groq queries to prevent or limit to drafted documents
 - **Component document view** (`sanityViewComponent`): Add a view to a document with a React component
 - **Structure document list** (`sanityDocList`): Adds a listItem in your desk structure for custom document list. Perfect for filtering by document values or adding docs from multiple types
+
 
 Feel free to contribute your snippets!
 

--- a/snippets/schema.code-snippets
+++ b/snippets/schema.code-snippets
@@ -112,5 +112,62 @@
       "\tto: [{ type: '${3:author}' }],",
       "},"
     ]
+  },
+  "Sanity Preview with Select": {
+    "description": "Add a basic preview with selection object in Sanity",
+    "prefix": "sanityPreviewSelect",
+    "body": [
+      "preview: {",
+      "\tselect: {",
+      "\t\ttitle: '${1:title}',",
+      "\t\tsubtitle: '${2:subtitle}',",
+      "\t\tmedia: '${3:image}',",
+      "\t},",
+      "},"
+    ]
+  },
+  "Sanity Select Object": {
+    "description": "Add a basic selection object for preview in Sanity",
+    "prefix": "sanitySelect",
+    "body": [
+      "\tselect: {",
+      "\t\ttitle: '${1:title}',",
+      "\t\tsubtitle: '${2:subtitle}',",
+      "\t\tmedia: '${3:image}',",
+      "\t},"
+    ]
+  },
+  "Sanity Prepare Function": {
+    "description": "Add a prepare function for preview in Sanity",
+    "prefix": "sanityPrepare",
+    "body": [
+      "prepare({ title, subtitle, media }) {",
+      "\treturn {",
+      "\t\ttitle: `${1:${title\\}}`,",
+      "\t\tsubtitle: `${2:${subtitle\\}}`,",
+      "\t\tmedia,",
+      "\t};",
+      "},"
+    ]
+  },
+  "Sanity Preview with Select and Prepare*": {
+    "description": "Add a preview with selection object and prepare function in Sanity",
+    "prefix": "sanityPreviewSelectPrepare",
+    "body": [
+      "preview: {",
+      "\tselect: {",
+      "\t\ttitle: '${1:title}',",
+      "\t\tsubtitle: '${2:subtitle}',",
+      "\t\tmedia: '${3:image}',",
+      "\t},",
+      "\tprepare({ title, subtitle, media }) {",
+      "\t\treturn {",
+      "\t\t\ttitle: `${4:\\${title\\}}`,",
+      "\t\t\tsubtitle: `${5:\\${subtitle\\}}`,",
+      "\t\t\tmedia,",
+      "\t\t};",
+      "\t},",
+      "},"
+    ]
   }
 }


### PR DESCRIPTION
I added 4 snippets for preview:

1. Basic preview with only select object
2. Full preview with select and prepare
3. Only selection object for when you are already inside `preview: {}`
4. Only prepare function for when you already have a `preview: { selection: {}}`

![image](https://user-images.githubusercontent.com/580312/97886047-69736680-1d28-11eb-9eb2-3e41cebd8560.png)

![image](https://user-images.githubusercontent.com/580312/97886014-624c5880-1d28-11eb-84a5-626a6dd9622e.png)
