### PR TITLE
Suggested change to make 'document' the default for new schema

### DIFF
--- a/snippets/schema.code-snippets
+++ b/snippets/schema.code-snippets
@@ -8,7 +8,7 @@
       "export default {",
       "\tname: '${1:$TM_FILENAME_BASE}',",
       "\ttitle: '${2:$TM_FILENAME_BASE}',",
-      "\ttype: '${3|object,document,image|}',",
+      "\ttype: '${3|document,object,image|}',",
       "\tfields: [",
       "\t\t{",
       "\t\t\tname: '${4:title}',",


### PR DESCRIPTION
When making new schema, I'm always thrown by `object` being the default. Looking at the code I now see that you can tab through the `type` to select `document`, but personally I'd have it as the default. I've only ever used the snippet for new documents.

Feel free to reject :D 